### PR TITLE
select node(s) to display with -n flag

### DIFF
--- a/cluster-smi-local.go
+++ b/cluster-smi-local.go
@@ -21,6 +21,9 @@ func main() {
 
 	showTimePtr := flag.Bool("t", false, "show time of events")
 	showProcessesPtr := flag.Bool("p", false, "verbose process information")
+	selectedNodes :=flag.String("n", "", "select node(s) to display information, " +
+                                         "muliple nodes are separated by comma without space " +
+                                         "(if not specified, all nodes will be shown)")
 	flag.Parse()
 
 	if err := nvml.InitNVML(); err != nil {
@@ -36,7 +39,7 @@ func main() {
 	log.Println("Cluster-SMI-Local is active. Press CTRL+C to shut down.")
 	for _ = range time.Tick(time.Duration(cfg.Tick) * time.Second) {
 		FetchNode(&cls.Nodes[0])
-		cls.Print(*showProcessesPtr, *showTimePtr, cfg.Timeout)
+		cls.Print(*selectedNodes, *showProcessesPtr, *showTimePtr, cfg.Timeout)
 	}
 
 }

--- a/cluster-smi.go
+++ b/cluster-smi.go
@@ -26,6 +26,9 @@ func main() {
 
 	showTimePtr := flag.Bool("t", false, "show time of events")
 	showProcessesPtr := flag.Bool("p", false, "verbose process information")
+	selectedNodes :=flag.String("n", "", "select node(s) to display information, " +
+                                         "muliple nodes are separated by comma without space " +
+                                         "(if not specified, all nodes will be shown)")
 	flag.Parse()
 
 	request_attempts := 0
@@ -74,7 +77,7 @@ func main() {
 		var clus cluster.Cluster
 		err = msgpack.Unmarshal(s, &clus)
 		clus.Sort()
-		clus.Print(*showProcessesPtr, *showTimePtr, cfg.Timeout)
+		clus.Print(*selectedNodes, *showProcessesPtr, *showTimePtr, cfg.Timeout)
 		time.Sleep(time.Duration(cfg.Tick) * time.Second)
 	}
 

--- a/cluster/data.go
+++ b/cluster/data.go
@@ -138,8 +138,9 @@ func (c *Cluster) Print(selected_nodes string, show_processes bool, show_time bo
 
 	// selected_nodes = "abc,def"
 	selected_names := strings.Split(selected_nodes, ",")
+	num_of_displayed_nodes := 0
 
-	for n_id, n := range c.Nodes {
+	for _, n := range c.Nodes {
 
 		timeout := now.Sub(n.Time).Seconds() > float64(timeout_threshold)
 		node_name := n.Name
@@ -156,6 +157,10 @@ func (c *Cluster) Print(selected_nodes string, show_processes bool, show_time bo
 			if node_valid == false {
 				continue
 			}
+		}
+
+		if num_of_displayed_nodes > 0 {
+			table.AddSeparator()
 		}
 
 		if timeout {
@@ -282,10 +287,7 @@ func (c *Cluster) Print(selected_nodes string, show_processes bool, show_time bo
 
 			}
 		}
-
-		if n_id < len(c.Nodes)-1 {
-			table.AddSeparator()
-		}
+		num_of_displayed_nodes += 1
 	}
 	fmt.Printf("\033[2J")
 	fmt.Println(time.Now().Format("Mon Jan 2 15:04:05 2006"))

--- a/cluster/data.go
+++ b/cluster/data.go
@@ -5,6 +5,7 @@ import (
 	"github.com/apcera/termtables"
 	"sort"
 	"time"
+	"strings"
 )
 
 type ByName []Node
@@ -115,7 +116,7 @@ func HumanizeSeconds(secs int64) string {
 
 }
 
-func (c *Cluster) Print(show_processes bool, show_time bool, timeout_threshold int) {
+func (c *Cluster) Print(selected_nodes string, show_processes bool, show_time bool, timeout_threshold int) {
 
 	table := termtables.CreateTable()
 
@@ -135,11 +136,27 @@ func (c *Cluster) Print(show_processes bool, show_time bool, timeout_threshold i
 
 	now := time.Now()
 
+	// selected_nodes = "abc,def"
+	selected_names := strings.Split(selected_nodes, ",")
+
 	for n_id, n := range c.Nodes {
 
 		timeout := now.Sub(n.Time).Seconds() > float64(timeout_threshold)
 		node_name := n.Name
 		node_lastseen := n.Time.Format("Mon Jan 2 15:04:05 2006")
+
+		if selected_nodes != "" {
+			node_valid := false
+			for _, selected_name := range selected_names {
+				if selected_name == node_name {
+					node_valid = true
+					break
+				}
+			}
+			if node_valid == false {
+				continue
+			}
+		}
 
 		if timeout {
 


### PR DESCRIPTION
Use ``-n node_name_1,node_name_2``flag to select the node(s) to be displayed. Multiple nodes should be separated by commas without spaces. If ``-n`` flag is not specified, all nodes will be displayed. 