### PR TITLE
ADD LD_LIBRARY_PATH for zerom1 export to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Finally:
 
 ```
 export PKG_CONFIG_PATH=/path/to/your_lib_folder/zeromq-4.1.0/dist/lib/pkgconfig/:$PKG_CONFIG_PATH
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/path/to/your_lib_folder/zeromq-4.1.0/dist/lib
 ```
 
 Edit the CFLAGS, LDFLAGS in file `nvvml/nvml.go` to match your setup.


### PR DESCRIPTION
Adding the LD_LIBRARY_PATH for zeromq prevents the following error when launching cluster-smi:
`error while loading shared libraries: libzmq.so.4: cannot open shared object file: No such file or directory`
@PatWie 