### PR TITLE
cluster-smi-node: allow using a SOCKS5 proxy

### DIFF
--- a/cluster-smi-node.go
+++ b/cluster-smi-node.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pebbe/zmq4"
 	"github.com/vmihailenco/msgpack"
 	"log"
+	"os"
 	"time"
 )
 
@@ -26,6 +27,12 @@ func main() {
 	SocketAddr := "tcp://" + cfg.RouterIp + ":" + cfg.Ports.Nodes
 	log.Println("Now pushing to", SocketAddr)
 	socket, err := zmq4.NewSocket(zmq4.PUSH)
+
+	zeromq_socks_proxy := os.Getenv("ZEROMQ_SOCKS_PROXY")
+	if zeromq_socks_proxy != "" {
+		socket.SetSocksProxy(zeromq_socks_proxy)
+	}
+
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Hi Patrick,

First, I'd like to express my gratitude towards you for developing and open-sourcing this great tool! It helps us manage our GPU servers in a much more efficient mannger.

Now the pull request itself. On some of our servers cluster-smi-node cannot communicate with cluster-smi-router due to firewall policies beyond our control. This patch allows us to make everything work via a SOCKS5 proxy. A typical usage is:

```
$ ZEROMQ_SOCKS_PROXY=127.0.0.1:8080 ./cluster-smi-node
```

Such a feature may help others, so I hope to see this patch included in this repo.

Best,

Chih-Hsuan